### PR TITLE
Add a safe utils.time_nonce function with a binary timestamp format.

### DIFF
--- a/libnacl/utils.py
+++ b/libnacl/utils.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import struct
+import time
+
 # Import nacl libs
 import libnacl
 import libnacl.encode
@@ -52,3 +55,14 @@ def rand_nonce():
     as crypto_box_NONCEBYTES
     '''
     return libnacl.randombytes(libnacl.crypto_box_NONCEBYTES)
+
+
+def time_nonce():
+    '''
+    Generates and returns a nonce as in rand_nonce() but using a timestamp for the first 8 bytes.
+    
+    This function now exists mostly for backwards compatibility, as rand_nonce() is usually preferred.
+    '''
+    nonce = rand_nonce()
+    return (struct.pack('=d', time.time()) + nonce)[:len(nonce)]
+


### PR DESCRIPTION
This should be just as safe as using `rand_nonce()`, and is useful since for minor version numbers (1.2.0 --> 1.3.0) is it best not to break backwards compatibility. 
