### PR TITLE
Fix _get_nacl() for libsodium >= 0.5.0

### DIFF
--- a/libnacl/__init__.py
+++ b/libnacl/__init__.py
@@ -43,6 +43,10 @@ def _get_nacl():
         except OSError:
             pass
         try:
+            return ctypes.cdll.LoadLibrary('libsodium.so.10')
+        except OSError:
+            pass
+        try:
             return ctypes.cdll.LoadLibrary('libsodium.so.5')
         except OSError:
             pass


### PR DESCRIPTION
libsodium 0.5.0 resulted in a SONAME bump to libsodium.so.10, so libnacl fails
to load it. This fixes that issue, and will allow libnacl to be built
against libsodium >= 0.5.0.

**NOTE: This will require that we cut a new libnacl release, so that it can be
built and added to EPEL.**
