### PR TITLE
fix randombytes_{random,uniform}

### DIFF
--- a/libnacl/__init__.py
+++ b/libnacl/__init__.py
@@ -499,7 +499,7 @@ def randombytes_random():
     '''
     Return a random 32-bit unsigned value
     '''
-    return nacl.randombytes_random().raw
+    return nacl.randombytes_random()
 
 
 def randombytes_stir():
@@ -516,7 +516,7 @@ def randombytes_uniform(upper_bound):
     '''
     Return a value between 0 and upper_bound using a uniform distribution
     '''
-    return nacl.randombytes_uniform(upper_bound).raw
+    return nacl.randombytes_uniform(upper_bound)
 
 
 # Utility functions

--- a/tests/unit/test_raw_random.py
+++ b/tests/unit/test_raw_random.py
@@ -1,0 +1,14 @@
+"""
+Basic tests for randombytes_* functions
+"""
+
+import libnacl
+import unittest
+
+
+class TestRandomBytes(unittest.TestCase):
+    def test_randombytes_random(self):
+        self.assertIsInstance(libnacl.randombytes_random(), int)
+
+    def test_randombytes_uniform(self):
+        self.assertIsInstance(libnacl.randombytes_uniform(200), int)


### PR DESCRIPTION
- these functions return `int` and, therefore, do not have `.raw`
  attribute
- add a positive test cases for each
