### PR TITLE
crypto_verify_32 is calling crypto_verify_16 

### DIFF
--- a/libnacl/__init__.py
+++ b/libnacl/__init__.py
@@ -501,7 +501,7 @@ def crypto_verify_32(string1, string2):
     matching prefix of string1 and string2. This often allows for easy
     timing attacks.
     '''
-    return not nacl.crypto_verify_16(string1, string2)
+    return not nacl.crypto_verify_32(string1, string2)
 
 
 # Random byte generation


### PR DESCRIPTION
fixed bug where crypto_verify_32 calls nacl.crypto_verify_16, where as it should be calling nacl.crypto_verify_32
