### PR TITLE
Add support for reading/writing from JSON streams (also msgpack)

### DIFF
--- a/libnacl/base.py
+++ b/libnacl/base.py
@@ -31,9 +31,9 @@ class BaseKey(object):
         if hasattr(self, 'seed'):
             return libnacl.encode.hex_encode(self.seed)
 
-    def save(self, path, serial='json'):
+    def for_json(self):
         '''
-        Safely save keys with perms of 0400
+        Return a dictionary of the secret values we need to store.
         '''
         pre = {}
         sk = self.hex_sk()
@@ -48,6 +48,15 @@ class BaseKey(object):
             pre['verify'] = vk.decode('utf-8')
         if seed:
             pre['sign'] = seed.decode('utf-8')
+
+        return pre
+
+    def save(self, path, serial='json'):
+        '''
+        Safely save keys with perms of 0400
+        '''
+        pre = self.for_json()
+
         if serial == 'msgpack':
             import msgpack
             packaged = msgpack.dumps(pre)

--- a/libnacl/utils.py
+++ b/libnacl/utils.py
@@ -12,19 +12,27 @@ import libnacl.sign
 import libnacl.dual
 
 
-def load_key(path, serial='json'):
+def load_key(path_or_file, serial='json'):
     '''
     Read in a key from a file and return the applicable key object based on
     the contents of the file
     '''
-    with open(path, 'rb') as fp_:
-        packaged = fp_.read()
-    if serial == 'msgpack':
-        import msgpack
-        key_data = msgpack.loads(packaged)
-    elif serial == 'json':
-        import json
-        key_data = json.loads(packaged.decode(encoding='UTF-8'))
+    if hasattr(path_or_file, 'read'):
+        stream = path_or_file
+    else:
+        stream = open(path_or_file, 'rb')
+
+    try:
+        if serial == 'msgpack':
+            import msgpack
+            key_data = msgpack.load(stream)
+        elif serial == 'json':
+            import json
+            key_data = json.load(stream, encoding='UTF-8')
+    finally:
+        if stream != path_or_file:
+            stream.close()
+
     if 'priv' in key_data and 'sign' in key_data and 'pub' in key_data:
         return libnacl.dual.DualSecret(
                 libnacl.encode.hex_decode(key_data['priv']),

--- a/tests/unit/test_save.py
+++ b/tests/unit/test_save.py
@@ -45,6 +45,12 @@ class TestSave(unittest.TestCase):
         alice_dec = bob_load_box.decrypt(alice_enc)
         self.assertEqual(bob_dec, msg)
         self.assertEqual(alice_dec, msg)
+
+        bob2 = libnacl.utils.load_key(file(bob_path, 'rb'))
+        self.assertEqual(bob.sk, bob2.sk)
+        self.assertEqual(bob.pk, bob2.pk)
+        self.assertEqual(bob.vk, bob2.vk)
+
         os.remove(bob_path)
         os.remove(alice_path)
 


### PR DESCRIPTION
To address concerns in issue #40 

By using `json.load` instead of `json.loads()` it might be possible to read from a stream, without affecting whatever may be next in the stream.

Enables support for `for_json()` feature of SimpleJSON