### PR TITLE
Add failing test for Unicode string encryption

### DIFF
--- a/tests/unit/test_secret.py
+++ b/tests/unit/test_secret.py
@@ -20,3 +20,23 @@ class TestSecret(unittest.TestCase):
         clear3 = box.decrypt(ctxt2)
         self.assertEqual(clear3, msg)
 
+    def test_unicode_issues(self):
+        msg = u'Unicode string'
+        box = libnacl.secret.SecretBox()
+
+        # Encrypting a unicode string (in py2) should
+        # probable assert, but instead it encryptes zeros,
+        # perhaps the high bytes in UCS-16?
+        ctxt = box.encrypt(msg)
+        self.assertNotEqual(msg, ctxt)
+
+        box2 = libnacl.secret.SecretBox(box.sk)
+        clear1 = box.decrypt(ctxt)
+
+        self.assertEqual(msg, clear1)
+        clear2 = box2.decrypt(ctxt)
+
+        self.assertEqual(clear1, clear2)
+        ctxt2 = box2.encrypt(msg)
+        clear3 = box.decrypt(ctxt2)
+        self.assertEqual(clear3, msg)


### PR DESCRIPTION
Found a bug. Encrypting a unicode string (py2) doesn't fail, but instead encrypts zeros.

I don't know enough about ctypes to fix in the right/best way but calls like this should fail since we always want to be encrypting bytes.

This is just the failing test case for now.
