### PR TITLE
Have libnacl look for libsodium in the nearest `lib` directory to where libnacl itself is installed

### DIFF
--- a/libnacl/__init__.py
+++ b/libnacl/__init__.py
@@ -55,6 +55,13 @@ def _get_nacl():
             return ctypes.cdll.LoadLibrary('/usr/local/lib/libsodium.so')
         except OSError:
             pass
+        try:
+            libidx = __file__.find('lib')
+            if libidx > 0:
+                libpath = __file__[0:libidx+3] + '/libsodium.so'
+                return ctypes.cdll.LoadLibrary(libpath)
+        except OSError:
+            pass
 
         for soname_ver in __SONAMES:
             try:


### PR DESCRIPTION
In some cases, especially when a custom Python is built, libnacl has trouble finding libsodium.  Currently libnacl looks first in the system's dynamic library path, then in /usr/local/lib, but errors out if it doesn't find it there.

If Python and dependencies are built and installed in an isolated directory tree, it's likely that that tree looks something like

```
/opt/python
/opt/python/lib
/opt/python/bin
```
etc.

and in this case libsodium probably will be in

```
/opt/python/lib/libsodium.so
```
and libnacl would be in

```
/opt/python/lib/site-packages/libnacl
```

So we'll just look for the 'lib' directory closest to the root and check in there as well as checking the other places for a libsodium.
