### PR TITLE
Add regressiontest for crypto_onetimeauth_verify

### DIFF
--- a/tests/unit/test_auth_verify.py
+++ b/tests/unit/test_auth_verify.py
@@ -1,0 +1,49 @@
+# Import nacl libs
+import libnacl
+
+# Import python libs
+import unittest
+
+
+class TestAuthVerify(unittest.TestCase):
+    '''
+    Test onetimeauth functions
+    '''
+    def test_auth_verify(self):
+        msg = b'Anybody can invent a cryptosystem he cannot break himself. Except Bruce Schneier.'
+        key1 = libnacl.utils.rand_nonce()
+        key2 = libnacl.utils.rand_nonce()
+
+        sig1 = libnacl.crypto_auth(msg, key1)
+        sig2 = libnacl.crypto_auth(msg, key2)
+
+        self.assertTrue(libnacl.crypto_auth_verify(sig1, msg, key1))
+        with self.assertRaises(ValueError) as context:
+            libnacl.crypto_auth_verify(sig1, msg, key2)
+        self.assertTrue('Failed to auth msg' in context.exception)
+
+        with self.assertRaises(ValueError) as context:
+            libnacl.crypto_auth_verify(sig2, msg, key1)
+        self.assertTrue('Failed to auth msg' in context.exception)
+        self.assertTrue(libnacl.crypto_auth_verify(sig2, msg, key2))
+
+    '''
+    Test onetimeauth functions
+    '''
+    def test_onetimeauth_verify(self):
+        msg = b'Anybody can invent a cryptosystem he cannot break himself. Except Bruce Schneier.'
+        key1 = libnacl.utils.rand_nonce()
+        key2 = libnacl.utils.rand_nonce()
+
+        sig1 = libnacl.crypto_onetimeauth(msg, key1)
+        sig2 = libnacl.crypto_onetimeauth(msg, key2)
+
+        self.assertTrue(libnacl.crypto_onetimeauth_verify(sig1, msg, key1))
+        with self.assertRaises(ValueError) as context:
+            libnacl.crypto_onetimeauth_verify(sig1, msg, key2)
+        self.assertTrue('Failed to auth msg' in context.exception)
+
+        with self.assertRaises(ValueError) as context:
+            libnacl.crypto_onetimeauth_verify(sig2, msg, key1)
+        self.assertTrue('Failed to auth msg' in context.exception)
+        self.assertTrue(libnacl.crypto_onetimeauth_verify(sig2, msg, key2))


### PR DESCRIPTION
```
>>> crypto_onetimeauth_verify(crypto_onetimeauth('yolo', 'secret'), 'yolo', 'secret')
'yolo'
>>>
>>> crypto_onetimeauth_verify(crypto_onetimeauth('yolo', 'forged'), 'yolo', 'secret')
'yolo'
>>>
```

https://gist.github.com/kpcyrd/1ec95f93b1b13f6af35c