### PR TITLE
use setuptools again - pip requires it anyhow.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Import python libs
-import os
-import sys
-
-if 'USE_SETUPTOOLS' in os.environ or 'setuptools' in sys.modules:
-    from setuptools import setup
-else:
-    from distutils.core import setup
+from setuptools import setup
 
 NAME = 'libnacl'
 DESC = ('Python bindings for libsodium/tweetnacl based on ctypes')


### PR DESCRIPTION
It's very hard to use modern Python without setuptools.
