### PR TITLE
remove one tweetnacl support - it is a small subset of the libsodium API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Python libnacl
 ==============
 
 This library is used to gain direct access to the functions exposed by
-Daniel J. Bernstein's nacl library via libsodium or tweetnacl. It has
+Daniel J. Bernstein's nacl library via libsodium. It has
 been constructed to maintain extensive documentation on how to use nacl
 as well as being completely portable. The file in libnacl/__init__.py
 can be pulled out and placed directly in any project to give a single file

--- a/doc/topics/releases/1.0.0.rst
+++ b/doc/topics/releases/1.0.0.rst
@@ -3,7 +3,7 @@ libnacl 1.0.0 Release Notes
 ===========================
 
 This is the first stable release of libnacl, the python bindings for Daniel J.
-Bernstein's nacl library via libsodium or tweetnacl.
+Bernstein's nacl library via libsodium.
 
 NaCl Base Functions
 ===================

--- a/libnacl/__init__.py
+++ b/libnacl/__init__.py
@@ -29,12 +29,8 @@ def _get_nacl():
                 )
             except OSError:
                 pass
-        try:
-            return ctypes.cdll.LoadLibrary('tweetnacl')
-        except OSError:
-            msg = ('Could not locate nacl lib, searched for libsodium, '
-                   'tweetnacl')
-            raise OSError(msg)
+        msg = 'Could not locate nacl lib, searched for libsodium'
+        raise OSError(msg)
     elif sys.platform.startswith('darwin'):
         try:
             return ctypes.cdll.LoadLibrary('libsodium.dylib')
@@ -46,12 +42,7 @@ def _get_nacl():
                 libpath = __file__[0:libidx+3] + '/libsodium.dylib'
                 return ctypes.cdll.LoadLibrary(libpath)
         except OSError:
-            pass
-        try:
-            return ctypes.cdll.LoadLibrary('tweetnacl.dylib')
-        except OSError:
-            msg = ('Could not locate nacl lib, searched for libsodium, '
-                   'tweetnacl')
+            msg = 'Could not locate nacl lib, searched for libsodium'
             raise OSError(msg)
     else:
         try:
@@ -77,14 +68,10 @@ def _get_nacl():
                 )
             except OSError:
                 pass
-        try:
-            return ctypes.cdll.LoadLibrary('tweetnacl.so')
-        except OSError:
-            msg = 'Could not locate nacl lib, searched for libsodium.so, '
-            for soname_ver in __SONAMES:
-                msg += 'libsodium.so.{0}, '.format(soname_ver)
-            msg += ' and tweetnacl.so'
-            raise OSError(msg)
+        msg = 'Could not locate nacl lib, searched for libsodium.so, '
+        for soname_ver in __SONAMES:
+            msg += 'libsodium.so.{0}, '.format(soname_ver)
+        raise OSError(msg)
 
 nacl = _get_nacl()
 

--- a/pkg/rpm/python-libnacl.spec
+++ b/pkg/rpm/python-libnacl.spec
@@ -13,9 +13,9 @@
 %global srcname libnacl
 
 Name:           python-%{srcname}
-Version:        1.3.5
+Version:        1.4.3
 Release:        1%{?dist}
-Summary:        Python bindings for libsodium/tweetnacl based on ctypes
+Summary:        Python bindings for libsodium based on ctypes
 
 Group:          Development/Libraries
 License:        ASL 2.0
@@ -41,7 +41,7 @@ BuildRequires:  python3-setuptools
 
 %description
 This library is used to gain direct access to the functions exposed by Daniel
-J. Bernstein's nacl library via libsodium or tweetnacl. It has been constructed
+J. Bernstein's nacl library via libsodium. It has been constructed
 to maintain extensive documentation on how to use nacl as well as being
 completely portable. The file in libnacl/__init__.py can be pulled out and
 placed directly in any project to give a single file binding to all of nacl.
@@ -50,13 +50,13 @@ This is the Python 2 build of the module.
 
 %if 0%{?with_python3}
 %package -n python3-%{srcname}
-Summary:  Python bindings for libsodium/tweetnacl based on ctypes
+Summary:  Python bindings for libsodium based on ctypes
 Group:    Development/Libraries
 Requires: libsodium
 
 %description -n python3-%{srcname}
 This library is used to gain direct access to the functions exposed by Daniel
-J. Bernstein's nacl library via libsodium or tweetnacl. It has been constructed
+J. Bernstein's nacl library via libsodium. It has been constructed
 to maintain extensive documentation on how to use nacl as well as being
 completely portable. The file in libnacl/__init__.py can be pulled out and
 placed directly in any project to give a single file binding to all of nacl.
@@ -66,7 +66,7 @@ This is the Python 3 build of the module.
 
 %if 0%{?rhel} == 5
 %package -n python26-%{srcname}
-Summary:        Python bindings for libsodium/tweetnacl based on ctypes
+Summary:        Python bindings for libsodium based on ctypes
 Group:          Development/Libraries
 BuildRequires:  python26
 BuildRequires:  libsodium
@@ -76,7 +76,7 @@ Requires:       libsodium
 
 %description -n python26-%{srcname}
 This library is used to gain direct access to the functions exposed by Daniel
-J. Bernstein's nacl library via libsodium or tweetnacl. It has been constructed
+J. Bernstein's nacl library via libsodium. It has been constructed
 to maintain extensive documentation on how to use nacl as well as being
 completely portable. The file in libnacl/__init__.py can be pulled out and
 placed directly in any project to give a single file binding to all of nacl.

--- a/pkg/suse/python-libnacl.spec
+++ b/pkg/suse/python-libnacl.spec
@@ -16,10 +16,10 @@
 #
 
 Name:           python-libnacl
-Version:        1.1.0
+Version:        1.4.3
 Release:        0
 License:        Apache-2.0
-Summary:        Python bindings for libsodium/tweetnacl based on ctypes
+Summary:        Python bindings for libsodium based on ctypes
 Url:            https://github.com/saltstack/libnacl
 Group:          Development/Languages/Python
 Source0:        https://pypi.python.org/packages/source/l/libnacl/libnacl-%{version}.tar.gz
@@ -38,7 +38,7 @@ BuildArch:      noarch
 %endif
 
 %description
-This library is used to gain direct access to the functions exposed by Daniel J. Bernstein's nacl library via libsodium or tweetnacl.
+This library is used to gain direct access to the functions exposed by Daniel J. Bernstein's nacl library via libsodium.
 It has been constructed to maintain extensive documentation on how to use nacl as well as being completely portable. The file 
 in libnacl/__init__.py can be pulled out and placed directly in any project to give a single file binding to all of nacl.
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ else:
     from distutils.core import setup
 
 NAME = 'libnacl'
-DESC = ('Python bindings for libsodium/tweetnacl based on ctypes')
+DESC = 'Python bindings for libsodium based on ctypes'
 
 # Version info -- read without importing
 _locals = {}


### PR DESCRIPTION
tweetnacl's is a very limited subset of libsodium API. By dropping it we can implement support for all the missing libsodium and maintaining consistency between installations.
 