### PR TITLE
crypto_onetimeauth:

### DIFF
--- a/libnacl/__init__.py
+++ b/libnacl/__init__.py
@@ -422,27 +422,71 @@ def crypto_auth_verify(tok, msg, key):
 # One time authentication
 
 
-def crypto_onetimeauth(msg, key):
-    '''
-    Constructs a one time authentication token for the given message msg using
+def crypto_onetimeauth_primitive():
+    """
+    Return the onetimeauth underlying primitive
+
+    Returns:
+        str: always ``poly1305``
+    """
+    func = nacl.crypto_onetimeauth_primitive
+    func.restype = ctypes.c_char_p
+    return func().decode()
+
+
+def crypto_onetimeauth(message, key):
+    """
+    Constructs a one time authentication token for the given message using
     a given secret key
-    '''
+
+    Args:
+        message (bytes): message to authenticate.
+        key (bytes): secret key - must be of crypto_onetimeauth_KEYBYTES length.
+
+    Returns:
+        bytes: an authenticator, of crypto_onetimeauth_BYTES length.
+
+    Raises:
+        ValueError: if arguments' length is wrong.
+    """
+    if len(key) != crypto_onetimeauth_KEYBYTES:
+        raise ValueError('Invalid secret key')
+
     tok = ctypes.create_string_buffer(crypto_onetimeauth_BYTES)
-    ret = nacl.crypto_onetimeauth(tok, msg, ctypes.c_ulonglong(len(msg)), key)
-    if ret:
-        raise ValueError('Failed to auth msg')
+    # cannot fail
+    _ = nacl.crypto_onetimeauth(
+        tok, message, ctypes.c_ulonglong(len(message)), key)
+
     return tok.raw[:crypto_onetimeauth_BYTES]
 
 
-def crypto_onetimeauth_verify(tok, msg, key):
-    '''
-    Verifies that the given authentication token is correct for the given
-    message and key
-    '''
-    ret = nacl.crypto_onetimeauth_verify(tok, msg, ctypes.c_ulonglong(len(msg)), key)
+def crypto_onetimeauth_verify(token, message, key):
+    """
+    Verifies, in constant time, that ``token`` is a correct authenticator for
+    the message using the secret key.
+
+    Args:
+        token (bytes): an authenticator of crypto_onetimeauth_BYTES length.
+        message (bytes): The message to authenticate.
+        key: key (bytes): secret key - must be of crypto_onetimeauth_KEYBYTES
+            length.
+
+    Returns:
+        bytes: secret key - must be of crypto_onetimeauth_KEYBYTES length.
+
+    Raises:
+        ValueError: if arguments' length is wrong or verification has failed.
+    """
+    if len(key) != crypto_onetimeauth_KEYBYTES:
+        raise ValueError('Invalid secret key')
+    if len(token) != crypto_onetimeauth_BYTES:
+        raise ValueError('Invalid authenticator')
+
+    ret = nacl.crypto_onetimeauth_verify(
+        token, message, ctypes.c_ulonglong(len(message)), key)
     if ret:
-        raise ValueError('Failed to auth msg')
-    return msg
+        raise ValueError('Failed to auth message')
+    return message
 
 # Hashing
 

--- a/tests/unit/test_auth_verify.py
+++ b/tests/unit/test_auth_verify.py
@@ -29,20 +29,31 @@ class TestAuthVerify(unittest.TestCase):
         self.assertTrue('Failed to auth msg' in context.exception.args)
 
     def test_onetimeauth_verify(self):
+        self.assertEqual("poly1305", libnacl.crypto_onetimeauth_primitive())
+
         msg = b'Anybody can invent a cryptosystem he cannot break himself. Except Bruce Schneier.'
-        key1 = libnacl.utils.rand_nonce()
-        key2 = libnacl.utils.rand_nonce()
+        key1 = libnacl.randombytes(libnacl.crypto_onetimeauth_KEYBYTES)
+        key2 = libnacl.randombytes(libnacl.crypto_onetimeauth_KEYBYTES)
 
         sig1 = libnacl.crypto_onetimeauth(msg, key1)
         sig2 = libnacl.crypto_onetimeauth(msg, key2)
+
+        with self.assertRaises(ValueError):
+            libnacl.crypto_onetimeauth(msg, b'too_short')
+
+        with self.assertRaises(ValueError):
+            libnacl.crypto_onetimeauth_verify(sig1, msg, b'too_short')
+
+        with self.assertRaises(ValueError):
+            libnacl.crypto_onetimeauth_verify(b'too_short', msg, key1)
 
         self.assertTrue(libnacl.crypto_onetimeauth_verify(sig1, msg, key1))
         self.assertTrue(libnacl.crypto_onetimeauth_verify(sig2, msg, key2))
         with self.assertRaises(ValueError) as context:
             libnacl.crypto_onetimeauth_verify(sig1, msg, key2)
-        self.assertTrue('Failed to auth msg' in context.exception.args)
+        self.assertTrue('Failed to auth message' in context.exception.args)
 
         with self.assertRaises(ValueError) as context:
             libnacl.crypto_onetimeauth_verify(sig2, msg, key1)
-        self.assertTrue('Failed to auth msg' in context.exception.args)
+        self.assertTrue('Failed to auth message' in context.exception.args)
 


### PR DESCRIPTION
* add check parameters + tests
* fix test where the wrong key length was used
* add primitive identification function