### PR TITLE
Add 18 to __SONAMES

### DIFF
--- a/libnacl/__init__.py
+++ b/libnacl/__init__.py
@@ -9,7 +9,7 @@ from libnacl.version import __version__
 import ctypes
 import sys
 
-__SONAMES = (17, 13, 10, 5, 4)
+__SONAMES = (18, 17, 13, 10, 5, 4)
 
 
 def _get_nacl():


### PR DESCRIPTION
Debian testing and unstable and Ubuntu Xenial are shipping it already,
so libnacl breaks there.