### PR TITLE
Addressing Issue #76 of saltstack/libnacl

### DIFF
--- a/pkg/rpm/python-libnacl.spec
+++ b/pkg/rpm/python-libnacl.spec
@@ -26,7 +26,7 @@ BuildRoot:      %{_tmppath}/%{srcname}-%{version}-%{release}-root-%(%{__id_u} -n
 BuildArch:      noarch
 
 BuildRequires:  libsodium
-Requires:       libsodium
+Requires:       libsodium >= 0.5.0
 
 %if ! (0%{?rhel} == 5)
 BuildRequires:  python


### PR DESCRIPTION
libnacl-1.4.4 doesn't work with libsodium-0.4.5-3.el6.x86_64 (latest version from CentOS EPEL)