### PR TITLE
Add 'bytes_eq' function

### DIFF
--- a/libnacl/__init__.py
+++ b/libnacl/__init__.py
@@ -593,6 +593,28 @@ def crypto_verify_64(string1, string2):
     '''
     return not nacl.crypto_verify_64(string1, string2)
 
+
+def bytes_eq(a, b):
+    '''
+    Compares two byte instances with one another. If `a` and `b` have
+    different lengths, return `False` immediately. Otherwise `a` and `b`
+    will be compared in constant time.
+
+    Return `True` in case `a` and `b` are equal. Otherwise `False`.
+
+    Raises :exc:`TypeError` in case `a` and `b` are not both of the type
+    :class:`bytes`.
+    '''
+    if not isinstance(a, bytes) or not isinstance(b, bytes):
+        raise TypeError('Both arguments must be bytes.')
+
+    len_a = len(a)
+    len_b = len(b)
+    if len_a != len_b:
+        return False
+
+    return nacl.sodium_memcmp(a, b, len_a) == 0
+
 # Random byte generation
 
 

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -12,9 +12,12 @@ class TestVerify(unittest.TestCase):
         v16 = libnacl.randombytes_buf(16)
         v16x = v16[:]
         self.assertTrue(libnacl.crypto_verify_16(v16, v16x))
+        self.assertTrue(libnacl.bytes_eq(v16, v16x))
         v16x = bytearray(v16x)
         v16x[libnacl.randombytes_random() & 15] += 1
-        self.assertFalse(libnacl.crypto_verify_16(v16, bytes(v16x)))
+        v16x = bytes(v16x)
+        self.assertFalse(libnacl.crypto_verify_16(v16, v16x))
+        self.assertFalse(libnacl.bytes_eq(v16, v16x))
 
         self.assertEqual(libnacl.crypto_verify_16_BYTES, 16)
 
@@ -22,9 +25,12 @@ class TestVerify(unittest.TestCase):
         v32 = libnacl.randombytes_buf(32)
         v32x = v32[:]
         self.assertTrue(libnacl.crypto_verify_32(v32, v32x))
+        self.assertTrue(libnacl.bytes_eq(v32, v32x))
         v32x = bytearray(v32x)
         v32x[libnacl.randombytes_random() & 31] += 1
-        self.assertFalse(libnacl.crypto_verify_32(v32, bytes(v32x)))
+        v32x = bytes(v32x)
+        self.assertFalse(libnacl.crypto_verify_32(v32, v32x))
+        self.assertFalse(libnacl.bytes_eq(v32, v32x))
 
         self.assertEqual(libnacl.crypto_verify_32_BYTES, 32)
 
@@ -32,8 +38,29 @@ class TestVerify(unittest.TestCase):
         v64 = libnacl.randombytes_buf(64)
         v64x = v64[:]
         self.assertTrue(libnacl.crypto_verify_64(v64, v64x))
+        self.assertTrue(libnacl.bytes_eq(v64, v64x))
         v64x = bytearray(v64x)
         v64x[libnacl.randombytes_random() & 63] += 1
-        self.assertFalse(libnacl.crypto_verify_64(v64, bytes(v64x)))
+        v64x = bytes(v64x)
+        self.assertFalse(libnacl.crypto_verify_64(v64, v64x))
+        self.assertFalse(libnacl.bytes_eq(v64, v64x))
 
         self.assertEqual(libnacl.crypto_verify_64_BYTES, 64)
+
+
+class TestVerifyBytesEq(unittest.TestCase):
+    def test_valid(self):
+        a = libnacl.randombytes_buf(122)
+        b = a[:]
+        self.assertTrue(libnacl.bytes_eq(a, bytes(b)))
+
+    def test_invalid_type(self):
+        a = libnacl.randombytes_buf(122)
+        b = bytearray(a)
+        with self.assertRaises(TypeError):
+            libnacl.bytes_eq(a, b)
+
+    def test_different_length(self):
+        a = libnacl.randombytes_buf(122)
+        b = a[:-1]
+        self.assertFalse(libnacl.bytes_eq(a, b))

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -49,10 +49,17 @@ class TestVerify(unittest.TestCase):
 
 
 class TestVerifyBytesEq(unittest.TestCase):
-    def test_valid(self):
+    def test_equal(self):
         a = libnacl.randombytes_buf(122)
         b = a[:]
-        self.assertTrue(libnacl.bytes_eq(a, bytes(b)))
+        self.assertTrue(libnacl.bytes_eq(a, b))
+
+    def test_different(self):
+        a = libnacl.randombytes_buf(122)
+        b = bytearray(a)
+        b[87] += 1
+        b = bytes(b)
+        self.assertFalse(libnacl.bytes_eq(a, b))
 
     def test_invalid_type(self):
         a = libnacl.randombytes_buf(122)


### PR DESCRIPTION
I've discovered that libsodium has a function to compare two byte sequences with one another in constant time and I require such a function in my project (I know that there are other packages providing this but I want to keep dependencies at a minimum).

Disclaimer: I'm not a cryptologist, so I'm not sure about the length comparison. However, the `cryptography` project [does the same](https://cryptography.io/en/latest/_modules/cryptography/hazmat/primitives/constant_time/#bytes_eq) although [they compare the length in the C function](https://github.com/pyca/cryptography/blob/68b3b1ea8661b98c7afc3243e84c998601b70f18/src/_cffi_src/hazmat_src/constant_time.c) which puzzles me a bit.