### PR TITLE
check public key length

### DIFF
--- a/libnacl/public.py
+++ b/libnacl/public.py
@@ -15,7 +15,10 @@ class PublicKey(libnacl.base.BaseKey):
     This class is used to manage public keys
     '''
     def __init__(self, pk):
-        self.pk = pk
+        if len(pk) == libnacl.crypto_box_PUBLICKEYBYTES:
+            self.pk = pk
+        else:
+            raise ValueError('Passed in invalid public key')
 
 
 class SecretKey(libnacl.base.BaseKey):


### PR DESCRIPTION
PublicKey accepts any key length without checking. We were bitten by this today, we passed in a base64 encoded key and PublicKey didn't complain but of course calculating a shared secret resulted in a different one.

SecretKey checks the key length, so there's no reason for PublicKey to not do so as well.