### PR TITLE
Mention exception change in 1.5.1 release notes

### DIFF
--- a/doc/topics/releases/1.5.1.rst
+++ b/doc/topics/releases/1.5.1.rst
@@ -7,3 +7,11 @@ Add Sealed Box Support
 
 A big thanks to Manatsawin Hanmongkolchai for adding in support for libsodium
 `Sealed Boxes`!
+
+Change Exception on Encrypt/Decrypt Failure
+===========================================
+
+If encryption or decryption fails, `CryptError` is raised instead of
+`ValueError`. This might be a breaking change for your application. See
+`#91 <https://github.com/saltstack/libnacl/issues/91>`__ and
+`#74 <https://github.com/saltstack/libnacl/issues/74>`__.


### PR DESCRIPTION
As already mentioned in https://github.com/saltstack/libnacl/pull/91#issuecomment-317757117.

The change in #91 is a breaking change for all applications that rely on catching encryption / decryption failures. Therefore it's important to mention it in the release notes.

The change could have been made reverse compatible by making `CryptError` a subclass of `ValueError`.

Do you have a policy regarding [semantic versioning](http://semver.org/)?