### PR TITLE
Restore crypto_aead_aes256gcm_*BYTES on old CPUs

### DIFF
--- a/libnacl/__init__.py
+++ b/libnacl/__init__.py
@@ -101,13 +101,10 @@ try:
 except AttributeError:
     HAS_SEAL = False
 try:
-    if nacl.crypto_aead_aes256gcm_is_available():
-        crypto_aead_aes256gcm_KEYBYTES = nacl.crypto_aead_aes256gcm_keybytes()
-        crypto_aead_aes256gcm_NPUBBYTES = nacl.crypto_aead_aes256gcm_npubbytes()
-        crypto_aead_aes256gcm_ABYTES = nacl.crypto_aead_aes256gcm_abytes()
-        HAS_AEAD_AES256GCM = True
-    else:
-        HAS_AEAD_AES256GCM = False
+    crypto_aead_aes256gcm_KEYBYTES = nacl.crypto_aead_aes256gcm_keybytes()
+    crypto_aead_aes256gcm_NPUBBYTES = nacl.crypto_aead_aes256gcm_npubbytes()
+    crypto_aead_aes256gcm_ABYTES = nacl.crypto_aead_aes256gcm_abytes()
+    HAS_AEAD_AES256GCM = bool(nacl.crypto_aead_aes256gcm_is_available())
     crypto_aead_chacha20poly1305_ietf_KEYBYTES = nacl.crypto_aead_chacha20poly1305_ietf_keybytes()
     crypto_aead_chacha20poly1305_ietf_NPUBBYTES = nacl.crypto_aead_chacha20poly1305_ietf_npubbytes()
     crypto_aead_chacha20poly1305_ietf_ABYTES = nacl.crypto_aead_chacha20poly1305_ietf_abytes()


### PR DESCRIPTION
`crypto_aead_aes256gcm_KEYBYTES`, `crypto_aead_aes256gcm_NPUBBYTES`, and
`crypto_aead_aes256gcm_ABYTES` should still be available even if CPU
support for AES256-GCM encryption/decryption is missing.

`libnacl.utils.aead_key` relies on this, and is needed by the
`test_ietf_aead` test which is run even without CPU support for
AES256-GCM.