### PR TITLE
Tweak MANIFEST.in to include only .py files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include LICENSE
 include AUTHORS
 include README.rst
-recursive-include tests *
+recursive-include tests *.py
 recursive-include doc *
 recursive-include pkg *


### PR DESCRIPTION
PyPI tarball for 1.6.1 contains lots of .pyc files from author's install. This causes problems. Tweak MANIFEST.in entry for future release to only include .py files to help prevent a recurrence.

Fixes #112 