### PR TITLE
Fix pypy tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-  - "pypy2.7-6.0"
+  - "pypy2"
   - "pypy3"
 
 install:


### PR DESCRIPTION
`pypy2.7-6.0` is not available `pypy2` is now on ubuntu18.