### PR TITLE
try ctypes.util.find_library first to locate libsodium

### DIFF
--- a/libnacl/__init__.py
+++ b/libnacl/__init__.py
@@ -4,7 +4,7 @@ Wrap libsodium routines
 '''
 # pylint: disable=C0103
 # Import python libs
-import ctypes
+import ctypes, ctypes.util
 import sys
 import os
 
@@ -16,6 +16,10 @@ def _get_nacl():
     Locate the nacl c libs to use
     '''
     # Import libsodium
+    l_path = ctypes.util.find_library('sodium')
+    if l_path is not None:
+        return ctypes.cdll.LoadLibrary(l_path)
+
     if sys.platform.startswith('win'):
         try:
             return ctypes.cdll.LoadLibrary('libsodium')


### PR DESCRIPTION
In MacOS, the environment variable DYLD_LIBRARY_PATH is used to specify the search path for .dylibs ([manpage](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlopen.3.html)) . However that path is not utilized by the call to ctypes.cdll.LoadLibrary. The ctypes module provides a function intended specifically to take a base library name and try to map it to a file path: ctypes.util.find_library. This change simply tries that mechanism first to locate the libsodium shared library.
