### PR TITLE
Fix installing tests in sdist, and include doc sources as well

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
         "Topic :: Security :: Cryptography",
     ]
 include = [
+    { path = "doc", format = "sdist" },
     { path = "tests", format = "sdist" },
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
         "Topic :: Security :: Cryptography",
     ]
 include = [
-    { path = "test", format = "sdist" },
+    { path = "tests", format = "sdist" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
- fix the `include` entry for tests to name the correct directory
- include documentation sources as well, to permit building offline docs